### PR TITLE
Added my dashboards as a service idea

### DIFF
--- a/daas/README.md
+++ b/daas/README.md
@@ -1,0 +1,18 @@
+# Dashboards as a Service
+
+Right now, lots of people want a simple way to throw together a simple dashboard without the hassle of setting up a web project and hosting the solution somewhere. We would provide an easy way to create a hosted dashboard solution that leverages Keen's Data Explorer.
+
+## Projects Used
+
+ * [dashboards](https://github.com/keen/dashboards)
+ * sinatra or rails? maybe something else?
+
+## Features
+
+ * Map named queries to a specific location in a dashboard
+ * Link a named query to a chart type
+ * Limit access to dashboards
+
+## Hosting
+
+Due to the mostly non-constant need to view dashboards, these can be hosted on Heroku without worrying about the paid tier.


### PR DESCRIPTION
# Dashboards as a Service

Right now, lots of people want a simple way to throw together a simple dashboard without the hassle of setting up a web project and hosting the solution somewhere. We would provide an easy way to create a hosted dashboard solution that leverages Keen's Data Explorer.
## Projects Used
- [dashboards](https://github.com/keen/dashboards)
- sinatra or rails? maybe something else?
## Features
- Map named queries to a specific location in a dashboard
- Link a named query to a chart type
- Limit access to dashboards
## Hosting

Due to the mostly non-constant need to view dashboards, these can be hosted on Heroku without worrying about the paid tier.
