### PR TITLE
Create README.md

### DIFF
--- a/keen_cache/README.md
+++ b/keen_cache/README.md
@@ -1,0 +1,7 @@
+Pebble created an open source library called [keen-cache](https://github.com/pebble/keen-cache) a while back.
+
+Essentially keen-cache is a lightweight server that you can host between your app and Keen, so that you can send events without worrying about Keen's write latency.
+
+However, keen-cache has fallen out of maintenance, and also has a lot of room for improvement. I think Keen, and the community, should take over development of this project.
+
+Whenever we decide to engage with this project, we should reach out to Pebble to discuss logistics and permission for adopting the project.


### PR DESCRIPTION
Pebble created an open source library called [keen-cache](https://github.com/pebble/keen-cache) a while back.

Essentially keen-cache is a lightweight server that you can host between your app and Keen, so that you can send events without worrying about Keen's write latency.

However, keen-cache has fallen out of maintenance, and also has a lot of room for improvement. I think Keen, and the community, should take over development of this project.

Whenever we decide to engage with this project, we should reach out to Pebble to discuss logistics and permission for adopting the project.
